### PR TITLE
Update minigzip.c

### DIFF
--- a/3rdparty/minigzip/minigzip.c
+++ b/3rdparty/minigzip/minigzip.c
@@ -49,6 +49,9 @@
 #include "zlib.h"
 #include <stdio.h>
 
+#include <stdlib.h>
+#include <string.h>
+
 #ifdef STDC
 #  include <string.h>
 #  include <stdlib.h>


### PR DESCRIPTION
Add required include declarations. This change fixes building with GCC 14 on Fedora 40.